### PR TITLE
Support whitespace in argument name strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Support whitespace in argument name strings.
+
+  Thanks to Arthur Rio in `PR #47 <https://github.com/adamchainz/unittest-parametrize/pull/47>`__.
+
 1.3.0 (2023-07-10)
 ------------------
 

--- a/src/unittest_parametrize/__init__.py
+++ b/src/unittest_parametrize/__init__.py
@@ -92,7 +92,7 @@ def parametrize(
     ids: Sequence[str | None] | None = None,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
     if isinstance(argnames, str):
-        argnames = argnames.split(",")
+        argnames = argnames.replace(" ", "").split(",")
 
     if len(argnames) == 0:
         raise ValueError("argnames must contain at least one element")

--- a/src/unittest_parametrize/__init__.py
+++ b/src/unittest_parametrize/__init__.py
@@ -92,7 +92,7 @@ def parametrize(
     ids: Sequence[str | None] | None = None,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
     if isinstance(argnames, str):
-        argnames = argnames.replace(" ", "").split(",")
+        argnames = [a.strip() for a in argnames.split(",")]
 
     if len(argnames) == 0:
         raise ValueError("argnames must contain at least one element")

--- a/tests/test_unittest_parametrize.py
+++ b/tests/test_unittest_parametrize.py
@@ -87,6 +87,23 @@ def test_wrong_argname():
     assert excinfo.value.args[0] == "got an unexpected keyword argument 'x'"
 
 
+def test_argname_whitespace_ignored():
+    ran = False
+
+    class VanillaTest(ParametrizedTestCase):
+        @parametrize(
+            "x, y",
+            [(1, 2)],
+        )
+        def test_something(self, x, y):
+            nonlocal ran
+            ran = True
+
+    run_tests(VanillaTest)
+
+    assert ran
+
+
 def test_param_invalid_id():
     with pytest.raises(ValueError) as excinfo:
         param(id="!")

--- a/tests/test_unittest_parametrize.py
+++ b/tests/test_unittest_parametrize.py
@@ -87,23 +87,6 @@ def test_wrong_argname():
     assert excinfo.value.args[0] == "got an unexpected keyword argument 'x'"
 
 
-def test_argname_whitespace_ignored():
-    ran = False
-
-    class VanillaTest(ParametrizedTestCase):
-        @parametrize(
-            "x, y",
-            [(1, 2)],
-        )
-        def test_something(self, x, y):
-            nonlocal ran
-            ran = True
-
-    run_tests(VanillaTest)
-
-    assert ran
-
-
 def test_param_invalid_id():
     with pytest.raises(ValueError) as excinfo:
         param(id="!")
@@ -215,6 +198,30 @@ def test_simple_parametrized():
     class SquareTests(ParametrizedTestCase):
         @parametrize(
             "x,expected",
+            [
+                (1, 1),
+                (2, 4),
+            ],
+        )
+        def test_square(self, x: int, expected: int) -> None:
+            nonlocal ran
+            ran += 1
+            self.assertEqual(x**2, expected)
+
+    run_tests(SquareTests)
+
+    assert ran == 2
+    assert not hasattr(SquareTests, "test_square")
+    assert hasattr(SquareTests, "test_square_0")
+    assert hasattr(SquareTests, "test_square_1")
+
+
+def test_argnames_whitespace():
+    ran = 0
+
+    class SquareTests(ParametrizedTestCase):
+        @parametrize(
+            "x, expected",
             [
                 (1, 1),
                 (2, 4),


### PR DESCRIPTION
Minor change to support whitespaces between argnames if not using a list.